### PR TITLE
Introduce `ContextEncoder` typeclass

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
-ThisBuild / tlBaseVersion := "0.3" // your current series x.y
+ThisBuild / tlBaseVersion := "0.4" // your current series x.y
 
 ThisBuild / organization := "io.github.bplommer"
 ThisBuild / organizationName := "Ben Plommer"

--- a/core/src/main/scala/catapult/ContextEncoder.scala
+++ b/core/src/main/scala/catapult/ContextEncoder.scala
@@ -1,0 +1,13 @@
+package catapult
+
+import com.launchdarkly.sdk.{LDContext, LDUser}
+
+trait ContextEncoder[Ctx] {
+  def encode(ctx: Ctx): LDContext
+}
+
+object ContextEncoder {
+  implicit val catapultContextEncoderForLdContext: ContextEncoder[LDContext] = identity
+
+  implicit val catapultContextEncoderForLdUser: ContextEncoder[LDUser] = LDContext.fromUser
+}

--- a/core/src/main/scala/catapult/ContextEncoder.scala
+++ b/core/src/main/scala/catapult/ContextEncoder.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Ben Plommer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package catapult
 
 import com.launchdarkly.sdk.{LDContext, LDUser}

--- a/core/src/main/scala/catapult/ContextEncoder.scala
+++ b/core/src/main/scala/catapult/ContextEncoder.scala
@@ -27,7 +27,7 @@ trait ContextEncoder[Ctx] {
 }
 
 object ContextEncoder {
-  implicit val catapultContextEncoderForLdContext: ContextEncoder[LDContext] = identity
+  implicit val catapultContextEncoderForLdContext: ContextEncoder[LDContext] = identity(_)
 
-  implicit val catapultContextEncoderForLdUser: ContextEncoder[LDUser] = LDContext.fromUser
+  implicit val catapultContextEncoderForLdUser: ContextEncoder[LDUser] = LDContext.fromUser(_)
 }

--- a/core/src/main/scala/catapult/ContextEncoder.scala
+++ b/core/src/main/scala/catapult/ContextEncoder.scala
@@ -2,6 +2,10 @@ package catapult
 
 import com.launchdarkly.sdk.{LDContext, LDUser}
 
+/** A typeclass for converting values of type [[Ctx]] into [[LDContext]]. An instance must be in scope when
+  * evaulating flags against a context represented by the [[Ctx]] type. Instances are provided for [[LDContext]]
+  * and [[LDUser]]; custom instances can be created to allow other types to be used.
+  */
 trait ContextEncoder[Ctx] {
   def encode(ctx: Ctx): LDContext
 }

--- a/core/src/main/scala/catapult/ContextEncoder.scala
+++ b/core/src/main/scala/catapult/ContextEncoder.scala
@@ -18,9 +18,9 @@ package catapult
 
 import com.launchdarkly.sdk.{LDContext, LDUser}
 
-/** A typeclass for converting values of type [[Ctx]] into [[LDContext]]. An instance must be in scope when
-  * evaulating flags against a context represented by the [[Ctx]] type. Instances are provided for [[LDContext]]
-  * and [[LDUser]]; custom instances can be created to allow other types to be used.
+/** A typeclass for converting values of type `Ctx` into [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/LDContext.html LDContext]]. An instance must be in scope when
+  * evaulating flags against a context represented by the `Ctx` type. Instances are provided for [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/LDContext.html LDContext]]
+  * and [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/LDUser.html LDUser]]; custom instances can be created to allow other types to be used.
   */
 trait ContextEncoder[Ctx] {
   def encode(ctx: Ctx): LDContext

--- a/core/src/main/scala/catapult/LaunchDarklyClient.scala
+++ b/core/src/main/scala/catapult/LaunchDarklyClient.scala
@@ -29,9 +29,9 @@ trait LaunchDarklyClient[F[_]] {
   /** @param featureKey the key of the flag to be evaluated
     * @param context the context against which the flag is being evaluated
     * @param defaultValue the value to use if evaluation fails for any reason
-    * @tparam Ctx the type representing the context; this can be [[com.launchdarkly.sdk.LDContext]], [[com.launchdarkly.sdk.LDUser]], or any type with a [[ContextEncoder]] instance in scope.
-    * @return the flag value, suspended in the [[F]] effect. If evaluation fails for any reason, or the evaluated value is not of type Boolean, returns the default value.
-    * @see [[com.launchdarkly.sdk.server.interfaces.LDClientInterface#boolVariation]]
+    * @tparam Ctx the type representing the context; this can be [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/LDContext.html LDContext]], [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/LDUser.html LDUser]], or any type with a [[ContextEncoder]] instance in scope.
+    * @return the flag value, suspended in the `F` effect. If evaluation fails for any reason, or the evaluated value is not of type Boolean, returns the default value.
+    * @see [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/server/interfaces/LDClientInterface.html#boolVariation(java.lang.String,com.launchdarkly.sdk.LDContext,boolean) LDClientInterface#boolVariation]]
     */
   def boolVariation[Ctx: ContextEncoder](
       featureKey: String,
@@ -42,9 +42,9 @@ trait LaunchDarklyClient[F[_]] {
   /** @param featureKey   the key of the flag to be evaluated
     * @param context      the context against which the flag is being evaluated
     * @param defaultValue the value to use if evaluation fails for any reason
-    * @tparam Ctx the type representing the context; this can be [[com.launchdarkly.sdk.LDContext]], [[com.launchdarkly.sdk.LDUser]], or any type with a [[ContextEncoder]] instance in scope.
-    * @return the flag value, suspended in the [[F]] effect. If evaluation fails for any reason, or the evaluated value is not of type String, returns the default value.
-    * @see [[com.launchdarkly.sdk.server.interfaces.LDClientInterface#stringVariation]]
+    * @tparam Ctx the type representing the context; this can be [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/LDContext.html LDContext]], [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/LDUser.html LDUser]], or any type with a [[ContextEncoder]] instance in scope.
+    * @return the flag value, suspended in the `F` effect. If evaluation fails for any reason, or the evaluated value is not of type String, returns the default value.
+    * @see [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/server/interfaces/LDClientInterface.html#stringVariation(java.lang.String,com.launchdarkly.sdk.LDContext,string) LDClientInterface#stringVariation]]
     */
   def stringVariation[Ctx: ContextEncoder](
       featureKey: String,
@@ -55,18 +55,18 @@ trait LaunchDarklyClient[F[_]] {
   /** @param featureKey   the key of the flag to be evaluated
     * @param context      the context against which the flag is being evaluated
     * @param defaultValue the value to use if evaluation fails for any reason
-    * @tparam Ctx the type representing the context; this can be [[com.launchdarkly.sdk.LDContext]], [[com.launchdarkly.sdk.LDUser]], or any type with a [[ContextEncoder]] instance in scope.
-    * @return the flag value, suspended in the [[F]] effect. If evaluation fails for any reason, or the evaluated value cannot be represented as type Int, returns the default value.
-    * @see [[com.launchdarkly.sdk.server.interfaces.LDClientInterface#intVariation]]
+    * @tparam Ctx the type representing the context; this can be [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/LDContext.html LDContext]], [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/LDUser.html LDUser]], or any type with a [[ContextEncoder]] instance in scope.
+    * @return the flag value, suspended in the `F` effect. If evaluation fails for any reason, or the evaluated value cannot be represented as type Int, returns the default value.
+    * @see [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/server/interfaces/LDClientInterface.html#intVariation(java.lang.String,com.launchdarkly.sdk.LDContext,int) LDClientInterface#intVariation]]
     */
   def intVariation[Ctx: ContextEncoder](featureKey: String, context: Ctx, defaultValue: Int): F[Int]
 
   /** @param featureKey   the key of the flag to be evaluated
     * @param context      the context against which the flag is being evaluated
     * @param defaultValue the value to use if evaluation fails for any reason
-    * @tparam Ctx the type representing the context; this can be [[com.launchdarkly.sdk.LDContext]], [[com.launchdarkly.sdk.LDUser]], or any type with a [[ContextEncoder]] instance in scope.
-    * @return the flag value, suspended in the [[F]] effect. If evaluation fails for any reason, or the evaluated value cannot be represented as type Double, returns the default value.
-    * @see [[com.launchdarkly.sdk.server.interfaces.LDClientInterface#doubleVariation]]
+    * @tparam Ctx the type representing the context; this can be [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/LDContext.html LDContext]], [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/LDUser.html LDUser]], or any type with a [[ContextEncoder]] instance in scope.
+    * @return the flag value, suspended in the `F` effect. If evaluation fails for any reason, or the evaluated value cannot be represented as type Double, returns the default value.
+    * @see [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/server/interfaces/LDClientInterface.html#doubleVariation(java.lang.String,com.launchdarkly.sdk.LDContext,double) LDClientInterface#doubleVariation]]
     */
   def doubleVariation[Ctx: ContextEncoder](
       featureKey: String,
@@ -77,9 +77,9 @@ trait LaunchDarklyClient[F[_]] {
   /** @param featureKey   the key of the flag to be evaluated
     * @param context      the context against which the flag is being evaluated
     * @param defaultValue the value to use if evaluation fails for any reason
-    * @tparam Ctx the type representing the context; this can be [[com.launchdarkly.sdk.LDContext]], [[com.launchdarkly.sdk.LDUser]], or any type with a [[ContextEncoder]] instance in scope.
-    * @return the flag value, suspended in the [[F]] effect. If evaluation fails for any reason, returns the default value.
-    * @see [[com.launchdarkly.sdk.server.interfaces.LDClientInterface#jsonValueVariation]]
+    * @tparam Ctx the type representing the context; this can be [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/LDContext.html LDContext]], [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/LDUser.html LDUser]], or any type with a [[ContextEncoder]] instance in scope.
+    * @return the flag value, suspended in the `F` effect. If evaluation fails for any reason, returns the default value.
+    * @see [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/server/interfaces/LDClientInterface.html#jsonValueVariation(java.lang.String,com.launchdarkly.sdk.LDContext,com.launchdarkly.sdk.LDValue) LDClientInterface#jsonValueVariation]]
     */
   def jsonVariation[Ctx: ContextEncoder](
       featureKey: String,
@@ -89,13 +89,13 @@ trait LaunchDarklyClient[F[_]] {
 
   /** @param featureKey   the key of the flag to be evaluated
     * @param context      the context against which the flag is being evaluated
-    * @tparam Ctx the type representing the context; this can be [[com.launchdarkly.sdk.LDContext]], [[com.launchdarkly.sdk.LDUser]], or any type with a [[ContextEncoder]] instance in scope.
-    * @return A [[Stream]] of [[FlagValueChangeEvent]] instances representing changes to the value of the flag in the provided context. Note: if the flag value changes multiple times in quick succession, some intermediate values may be missed; for example, a change from `1` to `2` to `3` may be represented only as a change from `1` to `3`
-    * @see [[com.launchdarkly.sdk.server.interfaces.FlagTracker]]
+    * @tparam Ctx the type representing the context; this can be [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/LDContext.html LDContext]], [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/LDUser.html LDUser]], or any type with a [[ContextEncoder]] instance in scope.
+    * @return A `Stream` of [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/server/interfaces/FlagValueChangeEvent.html FlagValueChangeEvent]] instances representing changes to the value of the flag in the provided context. Note: if the flag value changes multiple times in quick succession, some intermediate values may be missed; for example, a change from 1` to `2` to `3` may be represented only as a change from `1` to `3`
+    * @see [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/server/interfaces/FlagTracker.html FlagTracker]]
     */
   def listen[Ctx: ContextEncoder](featureKey: String, context: Ctx): Stream[F, FlagValueChangeEvent]
 
-  /** @see [[com.launchdarkly.sdk.server.interfaces.LDClientInterface#flush]]
+  /** @see [[https://javadoc.io/doc/com.launchdarkly/launchdarkly-java-server-sdk/latest/com/launchdarkly/sdk/server/interfaces/LDClientInterface.html#flush() LDClientInterface#flush]]
     */
   def flush: F[Unit]
 

--- a/core/src/main/scala/catapult/LaunchDarklyClient.scala
+++ b/core/src/main/scala/catapult/LaunchDarklyClient.scala
@@ -26,34 +26,77 @@ import fs2._
 
 trait LaunchDarklyClient[F[_]] {
 
+  /** @param featureKey the key of the flag to be evaluated
+    * @param context the context against which the flag is being evaluated
+    * @param defaultValue the value to use if evaluation fails for any reason
+    * @tparam Ctx the type representing the context; this can be [[com.launchdarkly.sdk.LDContext]], [[com.launchdarkly.sdk.LDUser]], or any type with a [[ContextEncoder]] instance in scope.
+    * @return the flag value, suspended in the [[F]] effect. If evaluation fails for any reason, or the evaluated value is not of type Boolean, returns the default value.
+    * @see [[com.launchdarkly.sdk.server.interfaces.LDClientInterface#boolVariation]]
+    */
   def boolVariation[Ctx: ContextEncoder](
       featureKey: String,
       context: Ctx,
       defaultValue: Boolean,
   ): F[Boolean]
 
+  /** @param featureKey   the key of the flag to be evaluated
+    * @param context      the context against which the flag is being evaluated
+    * @param defaultValue the value to use if evaluation fails for any reason
+    * @tparam Ctx the type representing the context; this can be [[com.launchdarkly.sdk.LDContext]], [[com.launchdarkly.sdk.LDUser]], or any type with a [[ContextEncoder]] instance in scope.
+    * @return the flag value, suspended in the [[F]] effect. If evaluation fails for any reason, or the evaluated value is not of type String, returns the default value.
+    * @see [[com.launchdarkly.sdk.server.interfaces.LDClientInterface#stringVariation]]
+    */
   def stringVariation[Ctx: ContextEncoder](
       featureKey: String,
       context: Ctx,
       defaultValue: String,
   ): F[String]
 
+  /** @param featureKey   the key of the flag to be evaluated
+    * @param context      the context against which the flag is being evaluated
+    * @param defaultValue the value to use if evaluation fails for any reason
+    * @tparam Ctx the type representing the context; this can be [[com.launchdarkly.sdk.LDContext]], [[com.launchdarkly.sdk.LDUser]], or any type with a [[ContextEncoder]] instance in scope.
+    * @return the flag value, suspended in the [[F]] effect. If evaluation fails for any reason, or the evaluated value cannot be represented as type Int, returns the default value.
+    * @see [[com.launchdarkly.sdk.server.interfaces.LDClientInterface#intVariation]]
+    */
   def intVariation[Ctx: ContextEncoder](featureKey: String, context: Ctx, defaultValue: Int): F[Int]
 
+  /** @param featureKey   the key of the flag to be evaluated
+    * @param context      the context against which the flag is being evaluated
+    * @param defaultValue the value to use if evaluation fails for any reason
+    * @tparam Ctx the type representing the context; this can be [[com.launchdarkly.sdk.LDContext]], [[com.launchdarkly.sdk.LDUser]], or any type with a [[ContextEncoder]] instance in scope.
+    * @return the flag value, suspended in the [[F]] effect. If evaluation fails for any reason, or the evaluated value cannot be represented as type Double, returns the default value.
+    * @see [[com.launchdarkly.sdk.server.interfaces.LDClientInterface#doubleVariation]]
+    */
   def doubleVariation[Ctx: ContextEncoder](
       featureKey: String,
       context: Ctx,
       defaultValue: Double,
   ): F[Double]
 
+  /** @param featureKey   the key of the flag to be evaluated
+    * @param context      the context against which the flag is being evaluated
+    * @param defaultValue the value to use if evaluation fails for any reason
+    * @tparam Ctx the type representing the context; this can be [[com.launchdarkly.sdk.LDContext]], [[com.launchdarkly.sdk.LDUser]], or any type with a [[ContextEncoder]] instance in scope.
+    * @return the flag value, suspended in the [[F]] effect. If evaluation fails for any reason, returns the default value.
+    * @see [[com.launchdarkly.sdk.server.interfaces.LDClientInterface#jsonValueVariation]]
+    */
   def jsonVariation[Ctx: ContextEncoder](
       featureKey: String,
       context: Ctx,
       defaultValue: LDValue,
   ): F[LDValue]
 
+  /** @param featureKey   the key of the flag to be evaluated
+    * @param context      the context against which the flag is being evaluated
+    * @tparam Ctx the type representing the context; this can be [[com.launchdarkly.sdk.LDContext]], [[com.launchdarkly.sdk.LDUser]], or any type with a [[ContextEncoder]] instance in scope.
+    * @return A [[Stream]] of [[FlagValueChangeEvent]] instances representing changes to the value of the flag in the provided context. Note: if the flag value changes multiple times in quick succession, some intermediate values may be missed; for example, a change from `1` to `2` to `3` may be represented only as a change from `1` to `3`
+    * @see [[com.launchdarkly.sdk.server.interfaces.FlagTracker]]
+    */
   def listen[Ctx: ContextEncoder](featureKey: String, context: Ctx): Stream[F, FlagValueChangeEvent]
 
+  /** @see [[com.launchdarkly.sdk.server.interfaces.LDClientInterface#flush]]
+    */
   def flush: F[Unit]
 
   def mapK[G[_]](fk: F ~> G): LaunchDarklyClient[G]


### PR DESCRIPTION
This removes the duplication of instance methods added in #8 and allows client code to use alternative representations of evaluation contexts.

The huge hardcoded URLs for links to javadocs are of course not pretty - I'm working on convincing scaladoc to generate them.