### PR TITLE
Make LDClient.Default private

### DIFF
--- a/core/src/main/scala/org.typelevel/catapult/LaunchDarklyClient.scala
+++ b/core/src/main/scala/org.typelevel/catapult/LaunchDarklyClient.scala
@@ -150,7 +150,7 @@ object LaunchDarklyClient {
         }
     }
 
-  trait Default[F[_]] extends LaunchDarklyClient[F] {
+  private trait Default[F[_]] extends LaunchDarklyClient[F] {
     self =>
     protected def unsafeWithJavaClient[A](f: LDClient => A): F[A]
 


### PR DESCRIPTION
This is an implementation detail - I don't think it's really something we want to support as part of the public API.