### PR TITLE
Fix initialization order bug

### DIFF
--- a/core/src/main/scala/org/typelevel/catapult/codec/LDCodec.scala
+++ b/core/src/main/scala/org/typelevel/catapult/codec/LDCodec.scala
@@ -174,7 +174,7 @@ object LDCodec {
       Validated.condNec(
         toDouble(n) == d,
         LDValue.of(d),
-        LDCodecFailure(LDReason.undecodableValue(LDValueType.NUMBER, typeName), history)
+        LDCodecFailure(LDReason.undecodableValue(LDValueType.NUMBER, typeName), history),
       )
     }
 

--- a/core/src/main/scala/org/typelevel/catapult/codec/LDCodec.scala
+++ b/core/src/main/scala/org/typelevel/catapult/codec/LDCodec.scala
@@ -168,21 +168,26 @@ object LDCodec {
       typeName: String,
       toDouble: N => Double,
       fromDouble: Double => N,
-  ): LDCodec[N] = LDCodec[Double].imapV[N](
-    n => {
+  ): LDCodec[N] = new LDCodec[N] {
+    override def encode(n: N, history: LDCursorHistory): LDCodecResult[LDValue] = {
       val d = toDouble(n)
-      Validated
-        .condNec(toDouble(n) == d, d, LDReason.undecodableValue(LDValueType.NUMBER, typeName))
-    },
-    d => {
-      val n = fromDouble(d)
       Validated.condNec(
         toDouble(n) == d,
-        n,
-        LDReason.unencodableValue(LDValueType.NUMBER, typeName),
+        LDValue.of(d),
+        LDCodecFailure(LDReason.undecodableValue(LDValueType.NUMBER, typeName), history)
       )
-    },
-  )
+    }
+
+    override def decode(c: LDCursor): LDCodecResult[N] =
+      c.checkType(LDValueType.NUMBER).map(_.value.doubleValue()).andThen { d =>
+        val n = fromDouble(d)
+        Validated.condNec(
+          toDouble(n) == d,
+          n,
+          c.fail(LDReason.unencodableValue(LDValueType.NUMBER, typeName)),
+        )
+      }
+  }
 
   implicit val floatInstance: LDCodec[Float] = numericInstance("Float", _.toDouble, _.toFloat)
 

--- a/core/src/main/scala/org/typelevel/catapult/codec/LDCodecWithInfallibleEncode.scala
+++ b/core/src/main/scala/org/typelevel/catapult/codec/LDCodecWithInfallibleEncode.scala
@@ -19,11 +19,7 @@ package org.typelevel.catapult.codec
 import cats.Invariant
 import cats.syntax.all.*
 import com.launchdarkly.sdk.{LDValue, LDValueType}
-import org.typelevel.catapult.codec.LDCodec.{
-  LDCodecResult,
-  withInfallibleEncode,
-  withInfallibleEncodeFull,
-}
+import org.typelevel.catapult.codec.LDCodec.{LDCodecResult, withInfallibleEncode}
 
 trait LDCodecWithInfallibleEncode[A] extends LDCodec[A] {
 
@@ -58,19 +54,19 @@ object LDCodecWithInfallibleEncode {
   implicit val ldValueInstance: LDCodecWithInfallibleEncode[LDValue] =
     withInfallibleEncode(identity, _.value)
 
-  implicit val booleanInstance: LDCodecWithInfallibleEncode[Boolean] = withInfallibleEncodeFull(
+  implicit val booleanInstance: LDCodecWithInfallibleEncode[Boolean] = instanceFull(
     LDValue.of,
     _.checkType(LDValueType.BOOLEAN).map(_.value.booleanValue()),
   )
 
-  implicit val stringInstance: LDCodecWithInfallibleEncode[String] = withInfallibleEncodeFull(
+  implicit val stringInstance: LDCodecWithInfallibleEncode[String] = instanceFull(
     LDValue.of,
     _.checkType(LDValueType.STRING).map(_.value.stringValue()),
   )
 
   // This is the canonical encoding of numbers in an LDValue, other
   // numerical types are derived from this because of this constraint.
-  implicit val doubleInstance: LDCodecWithInfallibleEncode[Double] = withInfallibleEncodeFull(
+  implicit val doubleInstance: LDCodecWithInfallibleEncode[Double] = instanceFull(
     LDValue.of,
     _.checkType(LDValueType.NUMBER).map(_.value.doubleValue()),
   )


### PR DESCRIPTION
This can happen if `LDCodec` is referenced before `LDCodecWithInfallibleEncode`, because of the way that `LDCodec.numericInstance` is defined in terms of `LDCodecWithInfallibleEncode.doubleInstance`.

Switching them so that `doubleInstance` is defined in terms of `numericInstance` appears to have fixed the issue.

```
java.lang.ExceptionInInitializerError
	at org.typelevel.catapult.codec.LDCodecWithInfallibleEncode$.<clinit>(LDCodecWithInfallibleEncode.scala:55)
	...
Caused by: java.lang.NullPointerException: Cannot invoke "org.typelevel.catapult.codec.LDCodec.imapV(scala.Function1, scala.Function1)" because the return value of "org.typelevel.catapult.codec.LDCodec$.apply(org.typelevel.catapult.codec.LDCodec)" is null
	at org.typelevel.catapult.codec.LDCodec$.numericInstance(LDCodec.scala:177)
	at org.typelevel.catapult.codec.LDCodec$.<clinit>(LDCodec.scala:187)
	... 19 more
```